### PR TITLE
fix(ci): skip _test.go files in semantic analysis

### DIFF
--- a/.github/workflows/semantic_analysis.yml
+++ b/.github/workflows/semantic_analysis.yml
@@ -144,6 +144,11 @@ jobs:
 
             if [[ "$NEW_FILE_REF" != *.go ]] && [[ "$OLD_FILE_REF" != *.go ]]; then continue; fi
 
+            # Skip test files. sfw's single-file loader can't form a package from a
+            # _test.go in isolation (it fails with "input packages list is empty"),
+            # and test changes don't alter the production semantics this check guards.
+            if [[ "$NEW_FILE_REF" == *_test.go ]] || [[ "$OLD_FILE_REF" == *_test.go ]]; then continue; fi
+
             if [ -f "$NEW_FILE_REF" ]; then
                 NEW_FILE="$NEW_FILE_REF"
             else


### PR DESCRIPTION
Final fix in the Semantic Analysis chain. With the Go toolchain and stderr fixes in place, sfw diff processes production files but errors on `_test.go` files (`input packages list is empty` -- the single-file loader can't form a package from a test file in isolation). Skip test files in the diff loop; they don't affect the production semantics this check guards. Verified locally: production files process (store.go 94%, constants 100%); test files fail and are now skipped.